### PR TITLE
fix: pass path arg to thread target_path kwarg

### DIFF
--- a/devon_agent/main.py
+++ b/devon_agent/main.py
@@ -32,12 +32,12 @@ def main():
 
     if repo_url:
         env.tools.git(path=path).clone(repo_url=repo_url, path=path)
-    
+
     if args.question:
         qa = True
         goal = args.question
 
-    agent = Thread(task=goal, qa=qa, environment=env)
+    agent = Thread(task=goal, qa=qa, environment=env, target_path=path)
 
     agent.run()
 


### PR DESCRIPTION
LMK thoughts on this PR

I wanted to be able to use Devon on arbitrary directories without needing to be in the directory itself.

I would run something like:

```
devon --goal "write tests for this javascript function" --path /home/me/js-repo
```

But it would not pull that code into it's context. I made this PR so that it would allow me to do that.

Hopefully this is helpful!