### PR TITLE
Add Groq (llama3-70b) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/entropy-research/Devon/assets/61808204/d42a8b9a-0211-4624-980
 
 1. `node.js` and `npm`
 2. `pipx`, if you don't have this go [here](https://pipx.pypa.io/stable/installation/)
-3. [**Anthropic**](https://console.anthropic.com/settings/keys) API Key or [**OpenAI**](https://platform.openai.com/api-keys) API key
+3. [**Anthropic**](https://console.anthropic.com/settings/keys) API Key or [**OpenAI**](https://platform.openai.com/api-keys) API key or [**Groq**](https://console.groq.com/keys) API key
 > We're currently working on supporting Windows!
 
 ## Installation commands
@@ -57,6 +57,10 @@ export ANTHROPIC_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #OR
 
 export OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+#OR
+
+export GROQ_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 Then to *run*, the command is:

--- a/devon-tui/source/cli.tsx
+++ b/devon-tui/source/cli.tsx
@@ -77,7 +77,7 @@ if (input[0] === 'configure') {
           type: 'list',
           name: 'modelName',
           message: 'Select the model name:',
-          choices: ['claude-opus', 'gpt4-o'],
+          choices: ['claude-opus', 'gpt4-o', 'llama-3-70b'],
         },
       ])
       .then((answers) => {

--- a/devon_agent/agents/default/agent.py
+++ b/devon_agent/agents/default/agent.py
@@ -5,12 +5,14 @@ from dataclasses import dataclass, field
 import traceback
 from typing import Optional, Tuple
 
-from devon_agent.agents.model import AnthropicModel, ModelArguments, OpenAiModel
+from devon_agent.agents.model import AnthropicModel, GroqModel, ModelArguments, OpenAiModel
 from devon_agent.agents.default.anthropic_prompts import anthropic_history_to_bash_history, anthropic_last_user_prompt_template_v3, anthropic_system_prompt_template_v3, anthropic_commands_to_command_docs
 from devon_agent.agents.default.openai_prompts import openai_last_user_prompt_template_v3, openai_system_prompt_template_v3, openai_commands_to_command_docs
 from devon_agent.agents.default.anthropic_prompts import (
     parse_response
 )
+from devon_agent.agents.default.llama3_prompts import llama3_commands_to_command_docs, llama3_history_to_bash_history, llama3_last_user_prompt_template_v3, llama3_parse_response, llama3_system_prompt_template_v3
+
 from devon_agent.tools.utils import get_cwd
 
 from devon_agent.udiff import Hallucination
@@ -42,7 +44,8 @@ class Agent:
 class TaskAgent(Agent):
     supported_models = {
         "gpt4-o": OpenAiModel,
-        "claude-opus": AnthropicModel
+        "claude-opus": AnthropicModel,
+        "llama-3-70b": GroqModel
     }
 
     def _format_editor_entry(self, k, v, PAGE_SIZE=50):
@@ -178,14 +181,38 @@ class TaskAgent(Agent):
                 )
 
                 messages = history + [{"role": "user", "content": last_user_prompt}]
+            elif self.model == "llama-3-70b":  
+                time.sleep(3)
+            
+                command_docs = (
+                    "Custom Commands Documentation:\n"
+                    + llama3_commands_to_command_docs(
+                        command_docs
+                    )
+                    + "\n"
+                )
 
+                history = llama3_history_to_bash_history(self.chat_history)
+                system_prompt = llama3_system_prompt_template_v3(command_docs)
+                last_user_prompt = llama3_last_user_prompt_template_v3(
+                    task, history, editor, get_cwd(
+                        {
+                            "session" : session,
+                            "environment" : session.default_environment,
+                            "state" : session.state
+                        }
+                    ), session.base_path, self.scratchpad
+                )
+
+                messages = [{"role": "user", "content": last_user_prompt}]
+            
             output = self.current_model.query(messages, system_message=system_prompt)
 
             thought = None
             action = None
 
             try:
-                thought, action, scratchpad = parse_response(output)
+                thought, action, scratchpad = llama3_parse_response(output)
                 if scratchpad:
                     self.scratchpad = scratchpad
             except Exception:

--- a/devon_agent/agents/default/agent.py
+++ b/devon_agent/agents/default/agent.py
@@ -11,7 +11,7 @@ from devon_agent.agents.default.openai_prompts import openai_last_user_prompt_te
 from devon_agent.agents.default.anthropic_prompts import (
     parse_response
 )
-from devon_agent.agents.default.llama3_prompts import llama3_commands_to_command_docs, llama3_history_to_bash_history, llama3_last_user_prompt_template_v3, llama3_parse_response, llama3_system_prompt_template_v3
+from devon_agent.agents.default.llama3_prompts import llama3_commands_to_command_docs, llama3_history_to_bash_history, llama3_last_user_prompt_template_v1, llama3_parse_response, llama3_system_prompt_template_v1
 
 from devon_agent.tools.utils import get_cwd
 
@@ -193,8 +193,8 @@ class TaskAgent(Agent):
                 )
 
                 history = llama3_history_to_bash_history(self.chat_history)
-                system_prompt = llama3_system_prompt_template_v3(command_docs)
-                last_user_prompt = llama3_last_user_prompt_template_v3(
+                system_prompt = llama3_system_prompt_template_v1(command_docs)
+                last_user_prompt = llama3_last_user_prompt_template_v1(
                     task, history, editor, get_cwd(
                         {
                             "session" : session,

--- a/devon_agent/agents/default/llama3_prompts.py
+++ b/devon_agent/agents/default/llama3_prompts.py
@@ -48,43 +48,45 @@ def object_to_xml(data: Union[dict, bool], root="object"):
 def print_tree(directory, level=0, indent=""):
     return "".join(f"\n{indent}├── {name}/" + print_tree(content, level + 1, indent + "│   ") if isinstance(content, dict) else f"\n{indent}├── {name}" for name, content in directory.items())
 
-def llama3_system_prompt_template_v3(command_docs: str):
+def llama3_system_prompt_template_v1(command_docs: str):
     return f"""
 <SETTING>
-You are an AI programmer fixing bugs in a project.
+ You are an autonomous programmer, and you're working directly in the command line with a special interface.
 
-Environment:
-- Editor (<EDITOR>): Open, edit, and auto-save code files. Focus on relevant files.
-- Terminal: Execute commands. Modify failed commands before retrying.
-- History (<HISTORY>): Previous thoughts and actions. Roleplay as if you had these.
+ Environment:
+- Editor (<EDITOR>): Open, edit, and auto-save code files. Focus on relevant files for each bug fix.
+- Terminal: Execute commands to perform actions. Modify failed commands before retrying.
+- History (<HISTORY>): Log of previous thoughts and actions. Act as if you've had these thoughts and performed these actions.
 
-Key constraints:
-- EDITING: Maintain formatting and conventions.
-- FILE MANAGEMENT: Keep only relevant files open.
-- COMMANDS: Modify failed commands before retrying.
-- SEARCH: Use efficient search techniques.
-- SUBMISSION: Verify fix resolves original issue.
-- CODEBASE: Choose general fixes over specific ones.
-- ASK_USER: Ask for input, feedback, or guidance.
+Constraints:
+- Maintain proper formatting and adhere to the project's coding conventions.
+- Keep only relevant files open. Close inactive files.
+- Modify failed commands before retrying.
+- Use efficient search techniques to locate relevant code elements.
+- Verify fixes resolve the original issue before submitting.
+- Prioritize general fixes over specific ones.
+- Ask for user input when needed for feedback, clarification, or guidance.
 
-You are on a branch, don't worry about changing core parts.
 </SETTING>
-<EDITOR>
-Currently open files will be listed here. Close unused files.
-</EDITOR>
 <COMMANDS>
 {command_docs}
 </COMMANDS>
 <RESPONSE FORMAT>
-Shell prompt: <cwd> $
-Required fields:
-<THOUGHT>Your reflection and planning</THOUGHT>
-<SCRATCHPAD>Information to write down</SCRATCHPAD>
-<COMMAND>A single executable command, no interactive commands</COMMAND>
+Shell prompt format: <cwd> $
+Required fields for each response:
+<THOUGHT>
+Your reflection, planning, and justification
+</THOUGHT>
+<SCRATCHPAD>
+Information you want to write down
+</SCRATCHPAD>
+<COMMAND>
+A single executable command (no interactive commands)
+</COMMAND>
 </RESPONSE FORMAT>
 """
 
-def llama3_last_user_prompt_template_v3(issue, history, editor, cwd, root_dir, scratchpad):
+def llama3_last_user_prompt_template_v1(issue, history, editor, cwd, root_dir, scratchpad):
     return f"""
 <SETTING>
 Objective: {issue}
@@ -107,6 +109,24 @@ Instructions:
 - Test edge cases and error handling
 - Manually verify UI and integration tests
 - Ensure tests pass before submitting
+</TESTING_TIPS>
+<PROBLEM_SOLVING>
+- Identify root cause and failure case
+- Fix underlying logic bug generally
+- Trace error to source
+- Identify flawed logic or edge case handling
+- Devise robust solution for core problem
+- Test fix thoroughly for potential impacts
+</PROBLEM_SOLVING>
+<EDITING_TIPS>
+- Use 'no_op' to pause and think
+- Match source lines precisely
+- Scroll to lines before changing
+- Make one change at a time
+- Finish edits before testing
+- Access limited to {root_dir}
+- Current directory: {cwd}
+</EDITING_TIPS>
 <HISTORY>
 {history}
 </HISTORY>

--- a/devon_agent/agents/default/llama3_prompts.py
+++ b/devon_agent/agents/default/llama3_prompts.py
@@ -1,0 +1,132 @@
+from typing import Dict, List, Union
+
+def llama3_commands_to_command_docs(commands: List[Dict]):
+    doc = ""
+    for command in commands:
+        doc += f"{command['signature']}\n{command['docstring']}\n"
+    return doc
+
+def editor_repr(editor):
+    return "\n\n".join(f"{file}:\n{editor[file]}" for file in editor)
+
+def llama3_history_to_bash_history(history):
+    # self.history.append(
+    # {
+    #     "role": "assistant",
+    #     "content": output,
+    #     "thought": thought,
+    #     "action": action,
+    #     "agent": self.name,
+
+    bash_history = ""
+    for entry in history:
+        if entry["role"] == "user":
+            result = entry["content"].strip() if entry["content"] else "" + "\n"
+            bash_history += f"<RESULT>\n{result}\n</RESULT>"
+        elif entry["role"] == "assistant":
+            bash_history += f"""
+<YOU>
+<THOUGHT>{entry['thought']}</THOUGHT>
+<COMMAND>
+{entry['action'][1:]}
+</COMMAND>
+</YOU>
+"""
+    return bash_history
+
+def object_to_xml(data: Union[dict, bool], root="object"):
+    xml = f"<{root}>"
+    if isinstance(data, dict):
+        xml += "".join(object_to_xml(value, key) for key, value in data.items())
+    elif isinstance(data, (list, tuple, set)):
+        xml += "".join(object_to_xml(item, "item") for item in data)
+    else:
+        xml += str(data)
+    xml += f"</{root}>"
+    return xml
+
+def print_tree(directory, level=0, indent=""):
+    return "".join(f"\n{indent}├── {name}/" + print_tree(content, level + 1, indent + "│   ") if isinstance(content, dict) else f"\n{indent}├── {name}" for name, content in directory.items())
+
+def llama3_system_prompt_template_v3(command_docs: str):
+    return f"""
+<SETTING>
+You are an AI programmer fixing bugs in a project.
+
+Environment:
+- Editor (<EDITOR>): Open, edit, and auto-save code files. Focus on relevant files.
+- Terminal: Execute commands. Modify failed commands before retrying.
+- History (<HISTORY>): Previous thoughts and actions. Roleplay as if you had these.
+
+Key constraints:
+- EDITING: Maintain formatting and conventions.
+- FILE MANAGEMENT: Keep only relevant files open.
+- COMMANDS: Modify failed commands before retrying.
+- SEARCH: Use efficient search techniques.
+- SUBMISSION: Verify fix resolves original issue.
+- CODEBASE: Choose general fixes over specific ones.
+- ASK_USER: Ask for input, feedback, or guidance.
+
+You are on a branch, don't worry about changing core parts.
+</SETTING>
+<EDITOR>
+Currently open files will be listed here. Close unused files.
+</EDITOR>
+<COMMANDS>
+{command_docs}
+</COMMANDS>
+<RESPONSE FORMAT>
+Shell prompt: <cwd> $
+Required fields:
+<THOUGHT>Your reflection and planning</THOUGHT>
+<SCRATCHPAD>Information to write down</SCRATCHPAD>
+<COMMAND>A single executable command, no interactive commands</COMMAND>
+</RESPONSE FORMAT>
+"""
+
+def llama3_last_user_prompt_template_v3(issue, history, editor, cwd, root_dir, scratchpad):
+    return f"""
+<SETTING>
+Objective: {issue}
+
+Instructions:
+- Edit files and run checks/tests
+- Submit with 'submit' when done
+- No interactive commands, write scripts instead
+</SETTING>
+<CONSTRAINTS>
+- One command at a time
+- Wait for feedback after each command
+- Locate classes/functions over files
+- Use 'no_op' for thinking time
+- Issue title/first line describes it succinctly
+</CONSTRAINTS>
+<TESTING_TIPS>
+- Write unit tests to verify fixes
+- Run tests frequently to catch regressions 
+- Test edge cases and error handling
+- Manually verify UI and integration tests
+- Ensure tests pass before submitting
+<HISTORY>
+{history}
+</HISTORY>
+<EDITOR>
+{editor}
+</EDITOR>
+<SCRATCHPAD>
+{scratchpad}
+</SCRATCHPAD>
+<DIRECTORY>
+{root_dir}
+</DIRECTORY>
+<cwd>{cwd}</cwd> $
+"""
+
+def llama3_parse_response(response):
+    thought = response.split("<THOUGHT>")[1].split("</THOUGHT>")[0]
+    action = response.split("<COMMAND>")[1].split("</COMMAND>")[0]
+    scratchpad = None
+    if "<SCRATCHPAD>" in response:
+        scratchpad = response.split("<SCRATCHPAD>")[1].split("</SCRATCHPAD>")[0]
+
+    return thought, action, scratchpad


### PR DESCRIPTION
# Groq llama3 support

- Adds option for llama3 on `devon configure`
- Update README about using GROQ API Keys
- Add more concise, objective llama3 prompts (v1)

Example:
![devon-groq](https://github.com/entropy-research/Devon/assets/4197222/a430411b-6853-4d5b-8837-1b8aca8def19)
